### PR TITLE
Fix/6/undef clock gettime

### DIFF
--- a/rockspecs/chronos-0.2-2.rockspec
+++ b/rockspecs/chronos-0.2-2.rockspec
@@ -1,0 +1,39 @@
+version = "0.2-2"
+dependencies = {
+    "lua >= 5.1",
+}
+package = "chronos"
+description = {
+    detailed = "Wrappers around a number of platform-specific monotonic\
+        timers. The highest resolution timer on each platform is used. This is\
+        typically `clock_gettime`, `gettimeofday`, `QueryPerformanceCounter`,\
+        or similar depending on the capabilities of the host. On a modern Linux\
+        system, nanosecond precision is achievable.\
+    ",
+    summary = "High resolution monotonic timers",
+    homepage = "https://github.com/ldrumm/chronos",
+    license = "MIT/X11",
+}
+build = {
+    type = "builtin",
+    platforms = {
+        unix = {
+            modules = {
+                chronos = {
+                    libraries = {
+                        "rt",
+                    },
+                    sources = "src/chronos.c",
+                },
+            },
+        },
+    },
+    modules = {
+        chronos = "src/chronos.c",
+    },
+}
+source = {
+    tag = "v0.2-2",
+    dir = "chronos-0.2-2",
+    url = "https://github.com/ldrumm/chronos/archive/v0.2-2.zip",
+}

--- a/update_rockspec.lua
+++ b/update_rockspec.lua
@@ -26,6 +26,16 @@ rockspec = {
     },
 
     build = {
+        platforms = {
+            unix = {
+                modules = {
+                    chronos = {
+                        sources = "src/chronos.c",
+                        libraries = {"rt"},
+                    },
+                },
+            },
+        },
         type = "builtin",
         modules = {
             chronos = "src/chronos.c",


### PR DESCRIPTION
@marcoonroad Can you confirm this fixes #6 before I merge?
`luarocks --local build https://raw.githubusercontent.com/ldrumm/chronos/v0.2-2/rockspecs/chronos-0.2-2.rockspec`

>Warning: falling back to wget - install luasec to get native HTTPS support
> gcc -O2 -fPIC -I/usr/include/lua5.1 -c src/chronos.c -o src/chronos.o
> gcc -shared -o chronos.so -L/usr/local/lib src/chronos.o -lrt
> chronos 0.2-2 is now installed in ~/.luarocks (license: MIT/X11)
